### PR TITLE
Add KH_GCP_SETUP_ADMIN_GITHUB_TOKEN and CLAUDE.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: golangci-lint
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Install dependencies
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       - name: Install dependencies
         run: make get.dependencies
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Install dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+make build          # compile binary
+make test           # unit tests + coverage
+make test.all       # unit + integration tests (requires gh and op CLIs)
+make lint           # golangci-lint
+make vet            # go fmt + go vet
+make run.local      # run without compiling
+
+# Single test
+go test -v ./pkg/github/... -run TestAddSecretToRepository
+go test -v ./cmd/github-distribute-secrets/... -run TestApplyConfiguration
+
+# Coverage HTML
+make test.report
+```
+
+Integration tests require working `gh` (GitHub CLI) and `op` (1Password CLI) installs. Tag: `//go:build integration`.
+
+## Architecture
+
+The tool reads `config.yml`, fetches secret values from 1Password, and writes them as GitHub repository secrets via CLI subprocesses — no direct API clients.
+
+**Data flow:**
+
+```
+config.yml
+  └─ internal/config → Configuration{common + per-repo maps}
+       └─ cmd/.../github_distribute_secrets.go → applyConfiguration()
+            ├─ pkg/onepassword → "op read <path>"  (results cached in-memory)
+            └─ pkg/github     → "gh secret set <key> --body <val> --repo <repo>"
+```
+
+**Key design choices:**
+
+- `pkg/cli.CommandRunner` is the single abstraction over `os/exec`. Everything else depends on it, which is what makes unit testing possible without real CLI tools.
+- `pkg/github` has two implementations of `GithubClient`: the real one and `dryRunGithubClient` (validates repos exist but skips writes). Selected at startup via `--dry-run`.
+- `internal/config.Configuration.GetConfigurationForRepository()` merges `common` secrets with repo-specific overrides. Repo-specific keys win.
+- `main.go` uses package-level function-pointer variables (`myNewGhClient`, `myNewOpClient`, etc.) for dependency injection in tests — not interfaces at the `main` level.
+
+**Runtime requirements:** `gh` and `op` must be authenticated before running.
+
+## config.yml format
+
+```yaml
+common:                    # applied to every repository
+  KEY: op://vault/item/field
+
+owner/repo:                # repo-specific; merged with common (overrides common on conflict)
+  EXTRA_KEY: op://vault/item/field
+```
+
+The `common` key is reserved; it is never treated as a repository name.

--- a/config.yml
+++ b/config.yml
@@ -12,6 +12,7 @@ koenighotze/pdfdebugger:
 
 koenighotze/kh-gcp-seed:
   GCP_RESOURCE_POSTFIX: op://kh-development/kh-gcp-bootstrap/gcp_resource_postfix
+  KH_GCP_SETUP_ADMIN_GITHUB_TOKEN: op://kh-development/KH_GCP_SETUP_ADMIN_GITHUB_TOKEN/token
 
 # koenighotze/go-playground:
 #   GCP_RESOURCE_POSTFIX: op://kh-development/kh-gcp-bootstrap/gcp_resource_postfix

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module koenighotze.de/github-distribute-secrets
 
-go 1.24.2
+go 1.25
 
 require github.com/goccy/go-yaml v1.19.2
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,7 @@ func (c Configuration) DumpConfiguration() string {
 	if len(commonConfig) > 0 {
 		buffer.WriteString("Common Secrets (applied to all repositories):\n")
 		for key, oppath := range commonConfig {
-			buffer.WriteString(fmt.Sprintf("  - %s: %s\n", key, oppath))
+			fmt.Fprintf(&buffer, "  - %s: %s\n", key, oppath)
 		}
 		buffer.WriteString("\n")
 	}
@@ -90,13 +90,13 @@ func (c Configuration) DumpConfiguration() string {
 	buffer.WriteString("Repository-Specific Configurations:\n")
 	for _, repo := range c.Repositories {
 		repoConfig := c.GetConfigurationForRepository(repo)
-		buffer.WriteString(fmt.Sprintf("- %s:\n", repo))
+		fmt.Fprintf(&buffer, "- %s:\n", repo)
 
 		if len(repoConfig) == 0 {
 			buffer.WriteString("  No secrets configured\n")
 		} else {
 			for key, oppath := range repoConfig {
-				buffer.WriteString(fmt.Sprintf("  - %s: %s\n", key, oppath))
+				fmt.Fprintf(&buffer, "  - %s: %s\n", key, oppath)
 			}
 		}
 		buffer.WriteString("\n")


### PR DESCRIPTION
## Summary

- Add \`KH_GCP_SETUP_ADMIN_GITHUB_TOKEN\` secret to \`koenighotze/kh-gcp-seed\` (sourced from 1Password vault \`kh-development\`)
- Add \`CLAUDE.md\` with build/test commands and architecture overview for Claude Code

## Test plan

- [ ] CI passes (lint, test, build)
- [ ] After merge: run the tool to verify secret is distributed to \`koenighotze/kh-gcp-seed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)