### PR TITLE
Add claude-sandbox to distribute Docker secrets

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -20,6 +20,9 @@ koenighotze/kh-gcp-seed:
 koenighotze/github-distribute-secrets:
   # no special flags
 
+koenighotze/claude-sandbox:
+  # no special secrets — Docker credentials come from common
+
 koenighotze/aws-website-terraform:
   AWS_ACCESS_KEY_ID: op://kh-development/aws-koenighotze-terraform-credentials/AWS_ACCESS_KEY_ID
   AWS_SECRET_ACCESS_KEY: op://kh-development/aws-koenighotze-terraform-credentials/AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
## Summary

- Add \`koenighotze/claude-sandbox\` to \`config.yml\` so the tool distributes secrets to it
- No new secrets needed — \`DOCKER_REGISTRY_USERNAME\` and \`DOCKER_REGISTRY_TOKEN\` are already in \`common\`

## Test plan

- [ ] CI passes
- [ ] After merge: run the tool and confirm Docker secrets are set on \`koenighotze/claude-sandbox\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)