### PR TITLE
fix: include secret path in error message

### DIFF
--- a/pkg/onepassword/onepassword_client.go
+++ b/pkg/onepassword/onepassword_client.go
@@ -25,7 +25,7 @@ type cliClient struct {
 func (d *cliClient) GetSecret(secretPath string) (secret string, err error) {
 	out, err := d.runner.Run("op", "read", secretPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to read secret %s: %w", secret, err)
+		return "", fmt.Errorf("failed to read secret %s: %w", secretPath, err)
 	}
 
 	secret = strings.TrimSpace(string(out))

--- a/pkg/onepassword/onepassword_client_test.go
+++ b/pkg/onepassword/onepassword_client_test.go
@@ -69,6 +69,16 @@ func TestGetSecret(t *testing.T) {
 		assert.ErrorContains(t, err, "bumm")
 		assert.ErrorIs(t, err, expectedError)
 	})
+
+	t.Run("should include the secret path in the error message", func(t *testing.T) {
+		client := cliClient{
+			runner: createMockOnePasswordCommandRunner(t, nil, errors.New("op failed")),
+		}
+
+		_, err := client.GetSecret(testSecretPath)
+
+		assert.ErrorContains(t, err, testSecretPath)
+	})
 }
 
 func TestGetSecretWithCache(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes bug where error message always showed empty string instead of the failing secret path
- Adds regression test asserting the path appears in the error message

## Test plan
- [x] New test fails before fix, passes after (Red-Green TDD)
- [x] All existing tests remain green

🤖 Generated with [Claude Code](https://claude.ai/code)