### PR TITLE
refactor: widen NewConfigFromReader to io.Reader

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"sort"
@@ -41,7 +42,7 @@ func extractRepositoryNamesFromConfig(rawConfig map[string]RepositoryConfigurati
 	return result
 }
 
-func NewConfigFromReader(reader *bytes.Reader) (config *Configuration, err error) {
+func NewConfigFromReader(reader io.Reader) (config *Configuration, err error) {
 	config = &Configuration{}
 	dec := yaml.NewDecoder(reader)
 	if err = dec.Decode(&config.RawConfig); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -114,6 +115,15 @@ func TestNewConfigFromReader(t *testing.T) {
 
 		assert.NotNil(t, err)
 		assert.Nil(t, result)
+	})
+
+	t.Run("should accept any io.Reader, not only bytes.Reader", func(t *testing.T) {
+		reader := strings.NewReader(yamlConfigurationCommonOnly)
+
+		result, err := NewConfigFromReader(reader)
+
+		assert.Nil(t, err)
+		assert.NotNil(t, result)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Changes `NewConfigFromReader` parameter from `*bytes.Reader` to `io.Reader`
- Adds regression test passing `*strings.Reader` to prove the wider contract
- No call-site changes needed

## Test plan
- [x] New test fails to compile before change, passes after (Red-Green TDD)
- [x] All existing tests remain green

🤖 Generated with [Claude Code](https://claude.ai/code)