### PR TITLE
test: remove unused yamlConfigurationOverwrites constant

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,15 +18,6 @@ repo1:
 repo2:
    KEY2: VAL2
 `
-	yamlConfigurationOverwrites = `
-common:
-   KEY0: VAL0
-repo1:
-   KEY1: VAL1
-repo2:
-   KEY2: VAL2
-`
-
 	yamlConfigurationCommonOnly = `
 common:
    KEY0: VAL0


### PR DESCRIPTION
## Summary
- Deletes `yamlConfigurationOverwrites` from config_test.go
- The constant was identical to `yamlConfigurationFull` and had zero usage sites

## Test plan
- [x] `grep -rn "yamlConfigurationOverwrites" .` returns zero results after deletion
- [x] `go test ./internal/config/...` green

🤖 Generated with [Claude Code](https://claude.ai/code)