### PR TITLE
fix: replace panic with error returns

### DIFF
--- a/cmd/github-distribute-secrets/github_distribute_secrets.go
+++ b/cmd/github-distribute-secrets/github_distribute_secrets.go
@@ -9,22 +9,21 @@ import (
 	"koenighotze.de/github-distribute-secrets/pkg/onepassword"
 )
 
-func githubSecretDistribution(configFileReader config.ConfigFileReader, op onepassword.OnePasswordClient, gh github.GithubClient, dumpConfig bool) bool {
+func githubSecretDistribution(configFileReader config.ConfigFileReader, op onepassword.OnePasswordClient, gh github.GithubClient, dumpConfig bool) error {
 	configuration, err := configFileReader.ReadConfiguration("./config.yml")
 	if err != nil {
-		panic(fmt.Errorf("failed to read config file: %w", err))
+		return fmt.Errorf("failed to read config file: %w", err)
 	}
 
 	if dumpConfig {
-		configDump := configuration.DumpConfiguration()
-		fmt.Println(configDump)
+		fmt.Println(configuration.DumpConfiguration())
 	}
 
-	if allOk := applyConfiguration(configuration, op, gh); !allOk {
-		log.Panicf("Configuration was not applied successfully!")
+	if !applyConfiguration(configuration, op, gh) {
+		return fmt.Errorf("configuration was not applied successfully")
 	}
 
-	return true
+	return nil
 }
 
 func applyConfigurationToRepository(configMap config.RepositoryConfiguration, repositoy string, op onepassword.OnePasswordClient, gh github.GithubClient) (ok bool) {

--- a/cmd/github-distribute-secrets/github_distribute_secrets_test.go
+++ b/cmd/github-distribute-secrets/github_distribute_secrets_test.go
@@ -188,7 +188,7 @@ func TestGithubSecretDistribution(t *testing.T) {
 			expectedConfig: configuration,
 		}
 
-		githubSecretDistribution(configFileReader, onePasswordClient, githubClient, false)
+		_ = githubSecretDistribution(configFileReader, onePasswordClient, githubClient, false)
 
 		assert.Equal(t, 1, configFileReader.calls)
 	})
@@ -200,12 +200,12 @@ func TestGithubSecretDistribution(t *testing.T) {
 			expectedConfig: configuration,
 		}
 
-		githubSecretDistribution(configFileReader, onePasswordClient, githubClient, false)
+		_ = githubSecretDistribution(configFileReader, onePasswordClient, githubClient, false)
 
 		assert.Equal(t, 1, githubClient.calls)
 	})
 
-	t.Run("should panic even if a single application fails", func(t *testing.T) {
+	t.Run("should return error if a single application fails", func(t *testing.T) {
 		onePasswordClient := &MockOnePasswordClient{}
 		githubClient := &mockGithubClient{
 			expectedError: assert.AnError,
@@ -214,21 +214,43 @@ func TestGithubSecretDistribution(t *testing.T) {
 			expectedConfig: configuration,
 		}
 
-		assert.Panics(t, func() {
-			githubSecretDistribution(configFileReader, onePasswordClient, githubClient, false)
-		})
+		err := githubSecretDistribution(configFileReader, onePasswordClient, githubClient, false)
+
+		assert.Error(t, err)
 	})
 
-	t.Run("should panic if reading the config failed", func(t *testing.T) {
+	t.Run("should return error if reading the config failed", func(t *testing.T) {
 		onePasswordClient := &MockOnePasswordClient{}
 		githubClient := &mockGithubClient{}
 		configFileReader := &MockConfigFileReader{
 			expectedError: assert.AnError,
 		}
 
-		assert.Panics(t, func() {
-			githubSecretDistribution(configFileReader, onePasswordClient, githubClient, false)
-		})
+		err := githubSecretDistribution(configFileReader, onePasswordClient, githubClient, false)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("should return error if reading config fails", func(t *testing.T) {
+		configFileReader := &MockConfigFileReader{expectedError: assert.AnError}
+
+		err := githubSecretDistribution(configFileReader, &MockOnePasswordClient{}, &mockGithubClient{}, false)
+
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("should return error if applying config fails", func(t *testing.T) {
+		configFileReader := &MockConfigFileReader{
+			expectedConfig: &config.Configuration{
+				RawConfig:    map[string]config.RepositoryConfiguration{"repo1": {"key": "val"}},
+				Repositories: []string{"repo1"},
+			},
+		}
+		githubClient := &mockGithubClient{expectedError: assert.AnError}
+
+		err := githubSecretDistribution(configFileReader, &MockOnePasswordClient{}, githubClient, false)
+
+		assert.Error(t, err)
 	})
 
 	t.Run("should dump the configuration after reading it", func(t *testing.T) {
@@ -257,10 +279,10 @@ func TestGithubSecretDistribution(t *testing.T) {
 		// The actual output check would require capturing stdout
 
 		// Act
-		result := githubSecretDistribution(configReader, onePasswordClient, githubClient, true)
+		err := githubSecretDistribution(configReader, onePasswordClient, githubClient, true)
 
 		// Assert
-		assert.True(t, result, "Function should complete successfully")
+		assert.NoError(t, err, "Function should complete successfully")
 		assert.Equal(t, 1, configReader.calls, "Should call ReadConfiguration once")
 	})
 
@@ -284,10 +306,10 @@ func TestGithubSecretDistribution(t *testing.T) {
 
 		// Act & Assert - No way to directly test stdout output in this test,
 		// but we can verify the function executes without issues
-		result := githubSecretDistribution(configReader, onePasswordClient, githubClient, false)
-		assert.True(t, result, "Function should complete successfully with dumpConfig=false")
+		err := githubSecretDistribution(configReader, onePasswordClient, githubClient, false)
+		assert.NoError(t, err, "Function should complete successfully with dumpConfig=false")
 
-		result = githubSecretDistribution(configReader, onePasswordClient, githubClient, true)
-		assert.True(t, result, "Function should complete successfully with dumpConfig=true")
+		err = githubSecretDistribution(configReader, onePasswordClient, githubClient, true)
+		assert.NoError(t, err, "Function should complete successfully with dumpConfig=true")
 	})
 }

--- a/cmd/github-distribute-secrets/main.go
+++ b/cmd/github-distribute-secrets/main.go
@@ -32,7 +32,7 @@ func main() {
 	gh := myNewGhClient(*dryRun)
 	op := myNewOpClient()
 
-	if !myGithubSecretDistribution(myNewConfigFileReader(), op, gh, *dumpConfig) {
-		log.Fatalln("Not all configuration was applied successfully!")
+	if err := myGithubSecretDistribution(myNewConfigFileReader(), op, gh, *dumpConfig); err != nil {
+		log.Fatalln(err)
 	}
 }

--- a/cmd/github-distribute-secrets/main_test.go
+++ b/cmd/github-distribute-secrets/main_test.go
@@ -30,9 +30,9 @@ func TestMain(t *testing.T) {
 		calledNewGhClientWithValue = dryRun
 		return &mockGithubClient{}
 	}
-	myGithubSecretDistribution = func(configFileReader config.ConfigFileReader, op onepassword.OnePasswordClient, gh github.GithubClient, dumpConfig bool) bool {
+	myGithubSecretDistribution = func(configFileReader config.ConfigFileReader, op onepassword.OnePasswordClient, gh github.GithubClient, dumpConfig bool) error {
 		calledGithubSecretDistribution = true
-		return true
+		return nil
 	}
 
 	t.Run("should use the dry run client if the flag is provided", func(t *testing.T) {
@@ -49,9 +49,9 @@ func TestMain(t *testing.T) {
 		os.Args = []string{"cmd", "--dump-config"}
 
 		dumpFlagValue := false
-		myGithubSecretDistribution = func(configFileReader config.ConfigFileReader, op onepassword.OnePasswordClient, gh github.GithubClient, dumpConfig bool) bool {
+		myGithubSecretDistribution = func(configFileReader config.ConfigFileReader, op onepassword.OnePasswordClient, gh github.GithubClient, dumpConfig bool) error {
 			dumpFlagValue = dumpConfig
-			return true
+			return nil
 		}
 
 		main()
@@ -64,9 +64,9 @@ func TestMain(t *testing.T) {
 		os.Args = []string{"cmd"}
 
 		dumpFlagValue := true
-		myGithubSecretDistribution = func(configFileReader config.ConfigFileReader, op onepassword.OnePasswordClient, gh github.GithubClient, dumpConfig bool) bool {
+		myGithubSecretDistribution = func(configFileReader config.ConfigFileReader, op onepassword.OnePasswordClient, gh github.GithubClient, dumpConfig bool) error {
 			dumpFlagValue = dumpConfig
-			return true
+			return nil
 		}
 
 		main()


### PR DESCRIPTION
## Summary
- \`githubSecretDistribution\` now returns \`error\` instead of \`bool\`
- Replaces both \`panic\` calls with \`return fmt.Errorf(...)\`
- Updates \`main.go\` call site and all test mock closures
- Converts \`assert.Panics\` tests to \`assert.Error\` tests

## Test plan
- [x] New error-return tests fail before change, pass after (Red-Green TDD)
- [x] Old panic tests converted to error assertions (not disabled)
- [x] \`make build\` and \`go test ./...\` green

🤖 Generated with [Claude Code](https://claude.ai/code)