### PR TITLE
refactor: fix repositoy typo in parameter names

### DIFF
--- a/cmd/github-distribute-secrets/github_distribute_secrets.go
+++ b/cmd/github-distribute-secrets/github_distribute_secrets.go
@@ -27,7 +27,7 @@ func githubSecretDistribution(configFileReader config.ConfigFileReader, op onepa
 	return true
 }
 
-func applyConfigurationToRepository(configMap config.RepositoryConfiguration, repositoy string, op onepassword.OnePasswordClient, gh github.GithubClient) (ok bool) {
+func applyConfigurationToRepository(configMap config.RepositoryConfiguration, repository string, op onepassword.OnePasswordClient, gh github.GithubClient) (ok bool) {
 	ok = true
 
 	for key, onePasswordPath := range configMap {
@@ -38,8 +38,8 @@ func applyConfigurationToRepository(configMap config.RepositoryConfiguration, re
 			continue
 		}
 
-		if err = gh.AddSecretToRepository(key, secret, repositoy); err != nil {
-			log.Printf("Error adding secret with key %s to repository %s: %v", key, repositoy, err)
+		if err = gh.AddSecretToRepository(key, secret, repository); err != nil {
+			log.Printf("Error adding secret with key %s to repository %s: %v", key, repository, err)
 			ok = false
 		}
 	}

--- a/cmd/github-distribute-secrets/github_distribute_secrets_test.go
+++ b/cmd/github-distribute-secrets/github_distribute_secrets_test.go
@@ -22,7 +22,7 @@ type mockGithubClient struct {
 	expectedError error
 }
 
-func (m *mockGithubClient) AddSecretToRepository(key string, secret string, repositoy string) (err error) {
+func (m *mockGithubClient) AddSecretToRepository(key string, secret string, repository string) (err error) {
 	m.calls++
 	return m.expectedError
 }

--- a/pkg/github/github_client.go
+++ b/pkg/github/github_client.go
@@ -8,17 +8,17 @@ import (
 )
 
 type GithubClient interface {
-	AddSecretToRepository(key string, secret string, repositoy string) (err error)
+	AddSecretToRepository(key string, secret string, repository string) (err error)
 }
 
 type cliGithubClient struct {
 	runner cli.CommandRunner
 }
 
-func (gh *cliGithubClient) AddSecretToRepository(key string, secret string, repositoy string) (err error) {
-	log.Printf("In repository %s. Adding secret with key %s", repositoy, key)
-	if _, err = gh.runner.Run("gh", "secret", "set", key, "--body", secret, "--repo", repositoy); err != nil {
-		return fmt.Errorf("failed adding secret as key %s to repository %s: %w", key, repositoy, err)
+func (gh *cliGithubClient) AddSecretToRepository(key string, secret string, repository string) (err error) {
+	log.Printf("In repository %s. Adding secret with key %s", repository, key)
+	if _, err = gh.runner.Run("gh", "secret", "set", key, "--body", secret, "--repo", repository); err != nil {
+		return fmt.Errorf("failed adding secret as key %s to repository %s: %w", key, repository, err)
 	}
 	return nil
 }

--- a/pkg/github/github_dry_run_client.go
+++ b/pkg/github/github_dry_run_client.go
@@ -11,10 +11,10 @@ type dryRunGithubClient struct {
 	runner cli.CommandRunner
 }
 
-func (gh *dryRunGithubClient) AddSecretToRepository(key string, secret string, repositoy string) (err error) {
-	log.Printf("DRY RUN: In repository %s. Should add secret with key %s", repositoy, key)
-	if _, err = gh.runner.Run("gh", "repo", "view", repositoy); err != nil {
-		return fmt.Errorf("repository %s does not seem to exist. %w", repositoy, err)
+func (gh *dryRunGithubClient) AddSecretToRepository(key string, secret string, repository string) (err error) {
+	log.Printf("DRY RUN: In repository %s. Should add secret with key %s", repository, key)
+	if _, err = gh.runner.Run("gh", "repo", "view", repository); err != nil {
+		return fmt.Errorf("repository %s does not seem to exist. %w", repository, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Renames parameter \`repositoy\` → \`repository\` across 4 files
- Pure rename, no behavior change
- Not a breaking change: Go interface matching uses types, not parameter names

## Test plan
- [x] \`grep -rn "repositoy" .\` returns zero results
- [x] \`go test ./...\` green

🤖 Generated with [Claude Code](https://claude.ai/code)