### PR TITLE
refactor: drop redundant log.Default() calls

### DIFF
--- a/cmd/github-distribute-secrets/github_distribute_secrets.go
+++ b/cmd/github-distribute-secrets/github_distribute_secrets.go
@@ -21,7 +21,7 @@ func githubSecretDistribution(configFileReader config.ConfigFileReader, op onepa
 	}
 
 	if allOk := applyConfiguration(configuration, op, gh); !allOk {
-		log.Default().Panicf("Configuration was not applied successfully!")
+		log.Panicf("Configuration was not applied successfully!")
 	}
 
 	return true
@@ -33,13 +33,13 @@ func applyConfigurationToRepository(configMap config.RepositoryConfiguration, re
 	for key, onePasswordPath := range configMap {
 		secret, err := op.GetSecret(onePasswordPath)
 		if err != nil {
-			log.Default().Printf("Error reading secret %s: %v", key, err)
+			log.Printf("Error reading secret %s: %v", key, err)
 			ok = false
 			continue
 		}
 
 		if err = gh.AddSecretToRepository(key, secret, repositoy); err != nil {
-			log.Default().Printf("Error adding secret with key %s to repository %s: %v", key, repositoy, err)
+			log.Printf("Error adding secret with key %s to repository %s: %v", key, repositoy, err)
 			ok = false
 		}
 	}
@@ -51,7 +51,7 @@ func applyConfiguration(configuration *config.Configuration, op onepassword.OneP
 	allOk = true
 	for _, repository := range configuration.Repositories {
 		if ok := applyConfigurationToRepository(configuration.GetConfigurationForRepository(repository), repository, op, gh); !ok {
-			log.Default().Printf("Cannot apply config to repository %s successfully!", repository)
+			log.Printf("Cannot apply config to repository %s successfully!", repository)
 			allOk = false
 		}
 	}

--- a/cmd/github-distribute-secrets/main.go
+++ b/cmd/github-distribute-secrets/main.go
@@ -33,6 +33,6 @@ func main() {
 	op := myNewOpClient()
 
 	if !myGithubSecretDistribution(myNewConfigFileReader(), op, gh, *dumpConfig) {
-		log.Default().Fatalln("Not all configuration was applied successfully!")
+		log.Fatalln("Not all configuration was applied successfully!")
 	}
 }

--- a/pkg/github/github_client.go
+++ b/pkg/github/github_client.go
@@ -16,7 +16,7 @@ type cliGithubClient struct {
 }
 
 func (gh *cliGithubClient) AddSecretToRepository(key string, secret string, repositoy string) (err error) {
-	log.Default().Printf("In repository %s. Adding secret with key %s", repositoy, key)
+	log.Printf("In repository %s. Adding secret with key %s", repositoy, key)
 	if _, err = gh.runner.Run("gh", "secret", "set", key, "--body", secret, "--repo", repositoy); err != nil {
 		return fmt.Errorf("failed adding secret as key %s to repository %s: %w", key, repositoy, err)
 	}

--- a/pkg/github/github_dry_run_client.go
+++ b/pkg/github/github_dry_run_client.go
@@ -12,7 +12,7 @@ type dryRunGithubClient struct {
 }
 
 func (gh *dryRunGithubClient) AddSecretToRepository(key string, secret string, repositoy string) (err error) {
-	log.Default().Printf("DRY RUN: In repository %s. Should add secret with key %s", repositoy, key)
+	log.Printf("DRY RUN: In repository %s. Should add secret with key %s", repositoy, key)
 	if _, err = gh.runner.Run("gh", "repo", "view", repositoy); err != nil {
 		return fmt.Errorf("repository %s does not seem to exist. %w", repositoy, err)
 	}


### PR DESCRIPTION
## Summary
- Replaces \`log.Default().X(...)\` with \`log.X(...)\` in 4 files
- Pure cosmetic cleanup — identical runtime behavior

## Test plan
- [x] \`grep -rn "log.Default()" .\` returns zero results
- [x] \`go test ./...\` green

🤖 Generated with [Claude Code](https://claude.ai/code)