### PR TITLE
docs: annotate design TODOs with status and PR refs, update config and standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ make test.report
 
 Integration tests require working `gh` (GitHub CLI) and `op` (1Password CLI) installs. Tag: `//go:build integration`.
 
-## Non negotiable standards
+## Non-negotiable standards
 
 - No pull request should have more than 300 lines of code changes. If you need more, split into multiple PRs and consider refactoring.
 - Try hard to keep files below 1000 lines. If you need more, consider refactoring.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Integration tests require working `gh` (GitHub CLI) and `op` (1Password CLI) ins
 
 ## Non negotiable standards
 
-- No pull request shoul have more than 300 lines of code changes. If you need more, split into multiple PRs and consider refactoring.
+- No pull request should have more than 300 lines of code changes. If you need more, split into multiple PRs and consider refactoring.
 - Try hard to keep files below 1000 lines. If you need more, consider refactoring.
 - Avoid spaghetti code. If you need more, consider refactoring.
 - Always go for simpler, human-readable code!

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,13 @@ make test.report
 
 Integration tests require working `gh` (GitHub CLI) and `op` (1Password CLI) installs. Tag: `//go:build integration`.
 
+## Non negotiable standards
+
+- No pull request shoul have more than 300 lines of code changes. If you need more, split into multiple PRs and consider refactoring.
+- Try hard to keep files below 1000 lines. If you need more, consider refactoring.
+- Avoid spaghetti code. If you need more, consider refactoring.
+- Always go for simpler, human-readable code!
+
 ## Architecture
 
 The tool reads `config.yml`, fetches secret values from 1Password, and writes them as GitHub repository secrets via CLI subprocesses — no direct API clients.

--- a/config.yml
+++ b/config.yml
@@ -23,6 +23,9 @@ koenighotze/github-distribute-secrets:
 koenighotze/claude-sandbox:
   # no special secrets — Docker credentials come from common
 
+koenighotze/claude-sandbox-nwave-ai:
+  # no special secrets — Docker credentials come from common
+
 koenighotze/aws-website-terraform:
   AWS_ACCESS_KEY_ID: op://kh-development/aws-koenighotze-terraform-credentials/AWS_ACCESS_KEY_ID
   AWS_SECRET_ACCESS_KEY: op://kh-development/aws-koenighotze-terraform-credentials/AWS_SECRET_ACCESS_KEY

--- a/design/TODO_01_Fix_secret_error_message.md
+++ b/design/TODO_01_Fix_secret_error_message.md
@@ -1,0 +1,95 @@
+# TODO 01 — Fix secret error message
+
+**Status:** DONE — merged as PR #36
+
+## Problem
+
+`pkg/onepassword/onepassword_client.go:27` formats the error with `secret` (always
+empty at that point) instead of `secretPath`. Every error reads:
+
+```
+failed to read secret : <underlying error>
+```
+
+The path that failed is invisible.
+
+## Branch
+
+```
+fix/secret-error-message
+```
+
+## Files
+
+- `pkg/onepassword/onepassword_client.go` (production)
+- `pkg/onepassword/onepassword_client_test.go` (test)
+
+---
+
+## RED — Write the failing test first
+
+Add to `TestGetSecret` in `pkg/onepassword/onepassword_client_test.go`:
+
+```go
+t.Run("should include the secret path in the error message", func(t *testing.T) {
+    client := cliClient{
+        runner: createMockOnePasswordCommandRunner(t, nil, errors.New("op failed")),
+    }
+
+    _, err := client.GetSecret(testSecretPath)
+
+    assert.ErrorContains(t, err, testSecretPath)
+})
+```
+
+### Verify RED
+
+```bash
+go test -v ./pkg/onepassword/... -run "TestGetSecret/should_include_the_secret_path"
+```
+
+Expected failure:
+
+```
+Error: "failed to read secret : op failed" does not contain "somepath"
+```
+
+If the test passes immediately — the bug is already fixed. Stop and investigate before continuing.
+
+---
+
+## GREEN — Minimal fix
+
+`pkg/onepassword/onepassword_client.go:27` — change `secret` to `secretPath`:
+
+```go
+// before
+return "", fmt.Errorf("failed to read secret %s: %w", secret, err)
+
+// after
+return "", fmt.Errorf("failed to read secret %s: %w", secretPath, err)
+```
+
+### Verify GREEN
+
+```bash
+go test ./pkg/onepassword/...
+```
+
+All tests must pass. No new failures.
+
+---
+
+## REFACTOR
+
+No cleanup needed. One-character fix.
+
+---
+
+## Verification checklist
+
+- [ ] Watched the test fail before touching production code
+- [ ] Failure was "does not contain" — not a compile error, not a wrong failure
+- [ ] Changed only the format argument
+- [ ] All `./pkg/onepassword/...` tests green
+- [ ] `make test` still green

--- a/design/TODO_02_Remove_panic_for_expected_failures.md
+++ b/design/TODO_02_Remove_panic_for_expected_failures.md
@@ -1,0 +1,181 @@
+# TODO 02 — Remove panic for expected failures
+
+**Status:** DONE — merged as PR #39
+
+## Problem
+
+`githubSecretDistribution` uses `panic` for expected operational errors (config file
+missing, secret push failure). The function always returns `true` or panics — the
+`bool` return type is dead code. The `false` branch in `main.go` is unreachable.
+
+Panics produce stack traces for routine CLI errors, which is confusing for end users.
+
+## Branch
+
+```
+fix/panic-to-error
+```
+
+## Files
+
+- `cmd/github-distribute-secrets/github_distribute_secrets.go`
+- `cmd/github-distribute-secrets/main.go`
+- `cmd/github-distribute-secrets/main_test.go`
+- `cmd/github-distribute-secrets/github_distribute_secrets_test.go`
+
+---
+
+## RED — Write the failing test first
+
+Add to `TestGithubSecretDistribution` in `github_distribute_secrets_test.go`:
+
+```go
+t.Run("should return error if reading config fails", func(t *testing.T) {
+    configFileReader := &MockConfigFileReader{expectedError: assert.AnError}
+
+    err := githubSecretDistribution(configFileReader, &MockOnePasswordClient{}, &mockGithubClient{}, false)
+
+    assert.ErrorIs(t, err, assert.AnError)
+})
+
+t.Run("should return error if applying config fails", func(t *testing.T) {
+    configFileReader := &MockConfigFileReader{
+        expectedConfig: &config.Configuration{
+            RawConfig:    map[string]config.RepositoryConfiguration{"repo1": {"key": "val"}},
+            Repositories: []string{"repo1"},
+        },
+    }
+    githubClient := &mockGithubClient{expectedError: assert.AnError}
+
+    err := githubSecretDistribution(configFileReader, &MockOnePasswordClient{}, githubClient, false)
+
+    assert.Error(t, err)
+})
+```
+
+### Verify RED
+
+```bash
+go test ./cmd/github-distribute-secrets/... 2>&1 | head -20
+```
+
+Expected: **compilation error** — `githubSecretDistribution` returns `bool`, not `error`.
+That compilation failure is the RED phase. Do not proceed until you see it.
+
+---
+
+## GREEN — Change the signature and fix callers
+
+### 1. `github_distribute_secrets.go`
+
+```go
+func githubSecretDistribution(
+    configFileReader config.ConfigFileReader,
+    op onepassword.OnePasswordClient,
+    gh github.GithubClient,
+    dumpConfig bool,
+) error {
+    configuration, err := configFileReader.ReadConfiguration("./config.yml")
+    if err != nil {
+        return fmt.Errorf("failed to read config file: %w", err)
+    }
+
+    if dumpConfig {
+        fmt.Println(configuration.DumpConfiguration())
+    }
+
+    if !applyConfiguration(configuration, op, gh) {
+        return fmt.Errorf("configuration was not applied successfully")
+    }
+
+    return nil
+}
+```
+
+### 2. `main.go`
+
+Update the var type and call site:
+
+```go
+var (
+    // ...
+    myGithubSecretDistribution = githubSecretDistribution
+)
+```
+
+The var type is inferred — it will update automatically once the function signature changes.
+
+Call site:
+
+```go
+if err := myGithubSecretDistribution(myNewConfigFileReader(), op, gh, *dumpConfig); err != nil {
+    log.Fatalln(err)
+}
+```
+
+### 3. `main_test.go`
+
+Update the mock closure type from `func(...) bool` to `func(...) error`:
+
+```go
+myGithubSecretDistribution = func(
+    configFileReader config.ConfigFileReader,
+    op onepassword.OnePasswordClient,
+    gh github.GithubClient,
+    dumpConfig bool,
+) error {
+    calledGithubSecretDistribution = true
+    return nil
+}
+```
+
+Update all three places in `main_test.go` where the mock is assigned.
+
+### 4. `github_distribute_secrets_test.go`
+
+Replace `assert.Panics` tests with error-return assertions:
+
+```go
+// before
+t.Run("should panic even if a single application fails", func(t *testing.T) {
+    ...
+    assert.Panics(t, func() {
+        githubSecretDistribution(configFileReader, onePasswordClient, githubClient, false)
+    })
+})
+
+// after
+t.Run("should return error if a single application fails", func(t *testing.T) {
+    ...
+    err := githubSecretDistribution(configFileReader, onePasswordClient, githubClient, false)
+    assert.Error(t, err)
+})
+```
+
+Same for the "should panic if reading the config failed" test.
+
+### Verify GREEN
+
+```bash
+go test ./cmd/github-distribute-secrets/...
+```
+
+All tests pass. No panics, no compile errors.
+
+---
+
+## REFACTOR
+
+Remove the now-unused `"fmt"` import from `github_distribute_secrets.go` if it drops out,
+or verify it stays (it's used in `fmt.Println`).
+
+---
+
+## Verification checklist
+
+- [ ] Saw compilation failure before touching production code
+- [ ] New tests use `assert.Error` / `assert.ErrorIs`, not `assert.Panics`
+- [ ] Existing panic tests replaced (not deleted — replaced with error assertions)
+- [ ] `main.go` call site updated — no `log.Fatalln` on `false` branch
+- [ ] `make test` green
+- [ ] `make build` compiles cleanly

--- a/design/TODO_03_Use_io_Reader_in_config.md
+++ b/design/TODO_03_Use_io_Reader_in_config.md
@@ -1,0 +1,90 @@
+# TODO 03 — Use `io.Reader` in `NewConfigFromReader`
+
+**Status:** DONE — merged as PR #37
+
+## Problem
+
+`NewConfigFromReader` in `internal/config/config.go:44` accepts `*bytes.Reader`
+instead of the `io.Reader` interface. The yaml decoder only needs `io.Reader`.
+This unnecessarily prevents passing other reader types (files, HTTP responses, strings).
+
+## Branch
+
+```
+refactor/io-reader-interface
+```
+
+## Files
+
+- `internal/config/config.go`
+- `internal/config/config_test.go`
+
+---
+
+## RED — Write the failing test first
+
+Add to `TestNewConfigFromReader` in `internal/config/config_test.go`:
+
+```go
+t.Run("should accept any io.Reader, not only bytes.Reader", func(t *testing.T) {
+    reader := strings.NewReader(yamlConfigurationCommonOnly)
+
+    result, err := NewConfigFromReader(reader)
+
+    assert.Nil(t, err)
+    assert.NotNil(t, result)
+})
+```
+
+Add `"strings"` to the test file's imports.
+
+### Verify RED
+
+```bash
+go test ./internal/config/... 2>&1 | head -20
+```
+
+Expected: **compilation error** — `*strings.Reader` cannot be used as `*bytes.Reader`.
+That is the RED. Do not proceed until you see it.
+
+---
+
+## GREEN — Widen the parameter type
+
+`internal/config/config.go:44` — change the parameter:
+
+```go
+// before
+func NewConfigFromReader(reader *bytes.Reader) (config *Configuration, err error) {
+
+// after
+func NewConfigFromReader(reader io.Reader) (config *Configuration, err error) {
+```
+
+Add `"io"` to imports. The `"bytes"` import stays — it is used elsewhere in the file.
+
+No call-site changes needed. All existing callers pass `*bytes.Reader` which satisfies `io.Reader`.
+
+### Verify GREEN
+
+```bash
+go test ./internal/config/...
+```
+
+All tests pass.
+
+---
+
+## REFACTOR
+
+No cleanup needed.
+
+---
+
+## Verification checklist
+
+- [ ] Saw compilation failure (`*strings.Reader` incompatible with `*bytes.Reader`)
+- [ ] Only changed the parameter type — no other production code altered
+- [ ] `"io"` added to imports, `"bytes"` import retained
+- [ ] All `./internal/config/...` tests green
+- [ ] `make test` green

--- a/design/TODO_05_Fix_repositoy_typo.md
+++ b/design/TODO_05_Fix_repositoy_typo.md
@@ -1,0 +1,78 @@
+# TODO 05 — Fix `repositoy` typo
+
+**Status:** DONE — merged as PR #40
+
+## Problem
+
+The parameter name `repositoy` (missing an `r`) appears in the `GithubClient` interface,
+both implementations, and the `applyConfigurationToRepository` function. Parameter names
+in Go interfaces don't affect callers, so this is not a breaking change.
+
+## Branch
+
+```
+refactor/fix-repositoy-typo
+```
+
+## Files
+
+- `pkg/github/github_client.go`
+- `pkg/github/github_dry_run_client.go`
+- `cmd/github-distribute-secrets/github_distribute_secrets.go`
+- `cmd/github-distribute-secrets/github_distribute_secrets_test.go`
+
+---
+
+## TDD note
+
+This is a pure rename with no behavior change. There is no failing test to write —
+the behavior is identical before and after. The "test" is the full test suite
+passing after the rename.
+
+**Rule:** Do not rename anything until you have confirmed the full suite is green on
+`main`. That green suite is your baseline. Any failure after the rename is a regression.
+
+---
+
+## Procedure
+
+### 1. Confirm baseline
+
+```bash
+make test
+```
+
+All tests green. Record this as the baseline.
+
+### 2. Rename — do not touch anything else
+
+In every file listed above, replace every occurrence of `repositoy` with `repository`.
+
+Occurrences to rename (parameter names only — not strings or comments):
+
+| File | Location |
+|------|----------|
+| `pkg/github/github_client.go` | interface method signature (line ~10) |
+| `pkg/github/github_client.go` | `cliGithubClient.AddSecretToRepository` param (line ~18) |
+| `pkg/github/github_dry_run_client.go` | `dryRunGithubClient.AddSecretToRepository` param (line ~14) |
+| `cmd/.../github_distribute_secrets.go` | `applyConfigurationToRepository` param + internal uses |
+| `cmd/.../github_distribute_secrets_test.go` | `mockGithubClient.AddSecretToRepository` param |
+
+### 3. Verify nothing broke
+
+```bash
+make test
+```
+
+Must be identical to baseline. Any new failure is a bug in the rename — fix it before
+proceeding.
+
+---
+
+## Verification checklist
+
+- [ ] Baseline `make test` green before starting
+- [ ] Used find-replace, not manual edits — avoid missing an occurrence
+- [ ] `grep -rn "repositoy" .` returns zero results after rename
+- [ ] `make test` green after rename — same result as baseline
+- [ ] `make build` compiles cleanly

--- a/design/TODO_06_Drop_log_Default.md
+++ b/design/TODO_06_Drop_log_Default.md
@@ -1,0 +1,78 @@
+# TODO 06 — Drop `log.Default()` calls
+
+**Status:** DONE — merged as PR #41
+
+## Problem
+
+`log.Default().Printf(...)`, `log.Default().Fatalln(...)`, and `log.Default().Panicf(...)`
+are used throughout the codebase. `log.Default()` returns the same default logger as the
+package-level functions — it is redundant noise.
+
+## Branch
+
+```
+refactor/drop-log-default
+```
+
+## Files
+
+- `cmd/github-distribute-secrets/github_distribute_secrets.go`
+- `pkg/github/github_client.go`
+- `cmd/github-distribute-secrets/main.go`
+
+---
+
+## TDD note
+
+This is a pure cosmetic substitution with no behavior change. No failing test to write.
+The verification is `make test` passing before and after — same as the typo fix.
+
+---
+
+## Procedure
+
+### 1. Confirm baseline
+
+```bash
+make test
+```
+
+All green.
+
+### 2. Replace — do not touch anything else
+
+In each file, replace `log.Default().` with nothing (i.e., use the package-level call directly):
+
+| Before | After |
+|--------|-------|
+| `log.Default().Printf(...)` | `log.Printf(...)` |
+| `log.Default().Fatalln(...)` | `log.Fatalln(...)` |
+| `log.Default().Panicf(...)` | `log.Panicf(...)` |
+
+Occurrences by file:
+
+**`github_distribute_secrets.go`**
+- `log.Default().Printf("Cannot apply config to repository %s successfully!", ...)` → `log.Printf(...)`
+
+**`github_client.go`**
+- `log.Default().Printf("In repository %s. Adding secret with key %s", ...)` → `log.Printf(...)`
+
+**`main.go`**
+- `log.Default().Fatalln(...)` → `log.Fatalln(...)`
+
+### 3. Verify nothing broke
+
+```bash
+make test
+```
+
+Identical to baseline.
+
+---
+
+## Verification checklist
+
+- [ ] Baseline `make test` green before starting
+- [ ] `grep -rn "log.Default()" .` returns zero results after change
+- [ ] `make test` green after change
+- [ ] `make build` compiles cleanly

--- a/design/TODO_07_Remove_dead_test_fixture.md
+++ b/design/TODO_07_Remove_dead_test_fixture.md
@@ -1,0 +1,83 @@
+# TODO 07 — Remove dead test fixture
+
+**Status:** DONE — merged as PR #38
+
+## Problem
+
+`yamlConfigurationOverwrites` in `internal/config/config_test.go` is identical to
+`yamlConfigurationFull` and is never referenced in any test. It is dead code that
+creates false familiarity — a reader might assume it tests override behavior.
+
+## Branch
+
+```
+refactor/remove-dead-test-fixture
+```
+
+## Files
+
+- `internal/config/config_test.go`
+
+---
+
+## TDD note
+
+Deleting an unused constant has no observable behavior. There is no failing test to write.
+The verification is `make test` passing before and after — same pattern as the typo fix.
+
+If the constant were referenced, the test suite would fail to compile on deletion — that
+compilation failure would serve as the RED phase.
+
+---
+
+## Procedure
+
+### 1. Confirm the constant is unused
+
+```bash
+grep -rn "yamlConfigurationOverwrites" .
+```
+
+Expected: exactly one result — the declaration itself. Zero usage sites.
+
+### 2. Confirm baseline
+
+```bash
+go test ./internal/config/...
+```
+
+All green.
+
+### 3. Delete the constant
+
+Remove lines 21–28 from `internal/config/config_test.go`:
+
+```go
+// delete this entire block
+yamlConfigurationOverwrites = `
+common:
+   KEY0: VAL0
+repo1:
+   KEY1: VAL1
+repo2:
+   KEY2: VAL2
+`
+```
+
+### 4. Verify
+
+```bash
+go test ./internal/config/...
+```
+
+Same result as baseline. No compile errors, no test failures.
+
+---
+
+## Verification checklist
+
+- [ ] `grep` confirmed zero usage sites before deleting
+- [ ] Baseline green before starting
+- [ ] Deleted the declaration only — no other changes
+- [ ] `go test ./internal/config/...` green after deletion
+- [ ] `make test` still green


### PR DESCRIPTION
## Summary

- Added `**Status:** DONE — merged as PR #N` to all six design TODO files so the folder reads as a changelog
- Added non-negotiable standards section to `CLAUDE.md` (PR size limit, file size limit, no spaghetti, readability)
- Added `koenighotze/claude-sandbox-nwave-ai` entry to `config.yml`

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] `make build` passes
- [ ] Design TODO files each show their merged PR number at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)